### PR TITLE
Don't require loopback IP in CSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Subject Alternative Names:
                         example.com
                         tls-app.default.svc.cluster.local
         IP Addresses:   10.228.0.10
-                        127.0.0.1
 Events:	<none>
 ```
 

--- a/main.go
+++ b/main.go
@@ -90,14 +90,13 @@ func main() {
 	// Gather the list of IP addresses for the certificate's IP SANs field which
 	// include:
 	//   - the pod IP address
-	//   - 127.0.0.1 for localhost access
 	//   - each service IP address that maps to this pod
 	ip := net.ParseIP(podIP)
 	if ip.To4() == nil && ip.To16() == nil {
 		log.Fatal("invalid pod IP address")
 	}
 
-	ipaddresses := []net.IP{ip, net.ParseIP("127.0.0.1")}
+	ipaddresses := []net.IP{ip}
 
 	for _, s := range strings.Split(serviceIPs, ",") {
 		if s == "" {


### PR DESCRIPTION
Including the loopback IP in a SAN is a poor security practice. It can
be added as a service IP if needed.