### PR TITLE
Add build container to allow for automated builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
-FROM alpine
-ADD gopath/bin/certificate-init-container /certificate-init-container
+FROM golang as builder
+
+WORKDIR /go/src/github.com/kelseyhightower/certificate-init-container
+COPY . /go/src/github.com/kelseyhightower/certificate-init-container/
+RUN go get -d -v
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo .
+
+FROM scratch
+COPY --from=builder /go/src/github.com/kelseyhightower/certificate-init-container/certificate-init-container /certificate-init-container
 ENTRYPOINT ["/certificate-init-container"]


### PR DESCRIPTION
Use this one for building for ourselves. If you want to use automated builds with any of the public docker container registries, here it is!